### PR TITLE
Fix strato order dom query to find the strato order

### DIFF
--- a/client.go
+++ b/client.go
@@ -109,11 +109,11 @@ func (c *StratoClient) authenticate() error {
 
 	// Send the request
 	resp, err = c.session.Do(req)
-
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusFound { // 302
 		// Strato uses a 302 redirect for successful login
 		// The user is redirected to the dashboard page
@@ -153,16 +153,20 @@ func (c *StratoClient) populatePackageID() error {
 		return nil
 	}
 	doc, err := htmlquery.Parse(resp.Body)
-
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
-	div := htmlquery.FindOne(doc, "//tr[@data-pkg-name-order='"+c.order+"']")
-	if div == nil {
+	// Find a table row with the order name first
+	pkgNode := htmlquery.FindOne(doc, "//tr[@data-pkg-name-order='"+c.order+"']")
+	// Find a div with the order name
+	if pkgNode == nil {
+		pkgNode = htmlquery.FindOne(doc, "//div[@data-pkg-name-order='"+c.order+"']")
+	}
+	if pkgNode == nil {
 		return errors.New("failed to find order")
 	}
-	linkNode := htmlquery.FindOne(div, ".//a")
+	linkNode := htmlquery.FindOne(pkgNode, ".//a")
 	if linkNode == nil {
 		return errors.New("failed to find link")
 	}


### PR DESCRIPTION
Seems Strato changed the dom on the customers landing page a little bit. To get the order node a TR-node must be queried. Added a fallback if TR-node is not present to try again the old DIV-node.